### PR TITLE
Added error messages to TS import

### DIFF
--- a/tomography_preprocessing/import_tilt_series/serialem.py
+++ b/tomography_preprocessing/import_tilt_series/serialem.py
@@ -69,12 +69,14 @@ def import_tilt_series_from_serial_em(
     console.log(f'Found {len(mdoc_files)} mdoc files and {len(tilt_image_files)} image files.')
     
     # Raise error if no tilt images or mdocs found
-    if not tilt_image_files: 
-        console.log('ERROR: Could not find any images files')
-        raise RuntimeError
-    if not mdoc_files:
-        console.log('ERROR: Could not find any mdoc files')
-        raise RuntimeError
+    if len(tilt_image_files) == 0: 
+        e = 'Could not find any image files'
+        console.log('ERROR: {e}')
+        raise RuntimeError(e)
+    if len(mdoc_files) == 0:
+        e = 'Could not find any mdoc files'
+        console.log('ERROR: {e}')
+        raise RuntimeError(e)
 
     # Get tomogram ids and construct paths for per-tilt-series STAR files
     tomogram_ids = [

--- a/tomography_preprocessing/import_tilt_series/serialem.py
+++ b/tomography_preprocessing/import_tilt_series/serialem.py
@@ -71,11 +71,11 @@ def import_tilt_series_from_serial_em(
     # Raise error if no tilt images or mdocs found
     if len(tilt_image_files) == 0: 
         e = 'Could not find any image files'
-        console.log('ERROR: {e}')
+        console.log(f'ERROR: {e}')
         raise RuntimeError(e)
     if len(mdoc_files) == 0:
         e = 'Could not find any mdoc files'
-        console.log('ERROR: {e}')
+        console.log(f'ERROR: {e}')
         raise RuntimeError(e)
 
     # Get tomogram ids and construct paths for per-tilt-series STAR files

--- a/tomography_preprocessing/import_tilt_series/serialem.py
+++ b/tomography_preprocessing/import_tilt_series/serialem.py
@@ -67,6 +67,14 @@ def import_tilt_series_from_serial_em(
     tilt_image_files = list(Path().glob(tilt_image_movie_pattern))
     mdoc_files = list(Path().glob(mdoc_file_pattern))
     console.log(f'Found {len(mdoc_files)} mdoc files and {len(tilt_image_files)} image files.')
+    
+    # Raise error if no tilt images or mdocs found
+    if not tilt_image_files: 
+        console.log('ERROR: Could not find any images files')
+        raise RuntimeError
+    if not mdoc_files:
+        console.log('ERROR: Could not find any mdoc files')
+        raise RuntimeError
 
     # Get tomogram ids and construct paths for per-tilt-series STAR files
     tomogram_ids = [


### PR DESCRIPTION
If no images or mdocs are found during TS import, import will fail and will provide an error. 