### PR TITLE
change binned pixel size data label to `rlnTomoTiltSeriesStarFile`

### DIFF
--- a/tomography_preprocessing/tilt_series_alignment/_generate_matrices.py
+++ b/tomography_preprocessing/tilt_series_alignment/_generate_matrices.py
@@ -35,8 +35,7 @@ def generate_relion_matrices(
     for tilt_series_id, tilt_series_df, tilt_image_df in tilt_series_metadata:
         euler_angles = tilt_image_df[['rlnTomoXTilt', 'rlnTomoYTilt', 'rlnTomoZRot']]
         shifts = tilt_image_df[['rlnTomoXShiftAngst', 'rlnTomoYShiftAngst']]
-        shifts /= tilt_series_df['rlnTomoTiltSeriesPixelSize'] if 'rlnTomoTiltSeriesPixelSize' in tilt_series_df.index \
-            else tilt_series_df['rlnMicrographOriginalPixelSize']
+        shifts /= tilt_series_df['rlnTomoTiltSeriesPixelSize']
         matrices = tilt_series_alignment_parameters_to_relion_projection_matrices(
             specimen_shifts=shifts,
             euler_angles=euler_angles,

--- a/tomography_preprocessing/tilt_series_alignment/_generate_matrices.py
+++ b/tomography_preprocessing/tilt_series_alignment/_generate_matrices.py
@@ -35,7 +35,7 @@ def generate_relion_matrices(
     for tilt_series_id, tilt_series_df, tilt_image_df in tilt_series_metadata:
         euler_angles = tilt_image_df[['rlnTomoXTilt', 'rlnTomoYTilt', 'rlnTomoZRot']]
         shifts = tilt_image_df[['rlnTomoXShiftAngst', 'rlnTomoYShiftAngst']]
-        shifts /= tilt_series_df['rlnMicrographPixelSize'] if 'rlnMicrographPixelSize' in tilt_series_df.index \
+        shifts /= tilt_series_df['rlnTomoTiltSeriesPixelSize'] if 'rlnTomoTiltSeriesPixelSize' in tilt_series_df.index \
             else tilt_series_df['rlnMicrographOriginalPixelSize']
         matrices = tilt_series_alignment_parameters_to_relion_projection_matrices(
             specimen_shifts=shifts,

--- a/tomography_preprocessing/tilt_series_alignment/aretomo/align_tilt_series.py
+++ b/tomography_preprocessing/tilt_series_alignment/aretomo/align_tilt_series.py
@@ -63,8 +63,7 @@ def align_single_tilt_series(
     run_aretomo_alignment(
         tilt_series_file=stack_directory / tilt_series_filename,
         tilt_angles=tilt_image_df['rlnTomoNominalStageTiltAngle'],
-        pixel_size=tilt_series_df['rlnTomoTiltSeriesPixelSize'] if 'rlnTomoTiltSeriesPixelSize' in tilt_series_df.index \
-            else tilt_series_df['rlnMicrographOriginalPixelSize'],
+        pixel_size=tilt_series_df['rlnTomoTiltSeriesPixelSize'],
         nominal_rotation_angle=tilt_image_df['rlnTomoNominalTiltAxisAngle'][0],
         output_directory=aretomo_directory,
         local_align=do_local_alignments,
@@ -77,8 +76,7 @@ def align_single_tilt_series(
     write_single_tilt_series_alignment_output(
         tilt_image_df=tilt_image_df,
         tilt_series_id=tilt_series_id,
-        pixel_size=tilt_series_df['rlnTomoTiltSeriesPixelSize'] if 'rlnTomoTiltSeriesPixelSize' in tilt_series_df.index \
-            else tilt_series_df['rlnMicrographOriginalPixelSize'],
+        pixel_size=tilt_series_df['rlnTomoTiltSeriesPixelSize'],
         alignment_directory=aretomo_directory,
         output_star_file=metadata_directory / tilt_image_metadata_filename,
     )

--- a/tomography_preprocessing/tilt_series_alignment/aretomo/align_tilt_series.py
+++ b/tomography_preprocessing/tilt_series_alignment/aretomo/align_tilt_series.py
@@ -63,7 +63,7 @@ def align_single_tilt_series(
     run_aretomo_alignment(
         tilt_series_file=stack_directory / tilt_series_filename,
         tilt_angles=tilt_image_df['rlnTomoNominalStageTiltAngle'],
-        pixel_size=tilt_series_df['rlnMicrographPixelSize'] if 'rlnMicrographPixelSize' in tilt_series_df.index \
+        pixel_size=tilt_series_df['rlnTomoTiltSeriesPixelSize'] if 'rlnTomoTiltSeriesPixelSize' in tilt_series_df.index \
             else tilt_series_df['rlnMicrographOriginalPixelSize'],
         nominal_rotation_angle=tilt_image_df['rlnTomoNominalTiltAxisAngle'][0],
         output_directory=aretomo_directory,
@@ -77,7 +77,7 @@ def align_single_tilt_series(
     write_single_tilt_series_alignment_output(
         tilt_image_df=tilt_image_df,
         tilt_series_id=tilt_series_id,
-        pixel_size=tilt_series_df['rlnMicrographPixelSize'] if 'rlnMicrographPixelSize' in tilt_series_df.index \
+        pixel_size=tilt_series_df['rlnTomoTiltSeriesPixelSize'] if 'rlnTomoTiltSeriesPixelSize' in tilt_series_df.index \
             else tilt_series_df['rlnMicrographOriginalPixelSize'],
         alignment_directory=aretomo_directory,
         output_star_file=metadata_directory / tilt_image_metadata_filename,

--- a/tomography_preprocessing/tilt_series_alignment/imod/align_tilt_series.py
+++ b/tomography_preprocessing/tilt_series_alignment/imod/align_tilt_series.py
@@ -56,7 +56,7 @@ def align_single_tilt_series(
     alignment_function(
         tilt_series_file=stack_directory / tilt_series_filename,
         tilt_angles=tilt_image_df['rlnTomoNominalStageTiltAngle'],
-        pixel_size=tilt_series_df['rlnMicrographPixelSize'] if 'rlnMicrographPixelSize' in tilt_series_df.index \
+        pixel_size=tilt_series_df['rlnTomoTiltSeriesPixelSize'] if 'rlnTomoTiltSeriesPixelSize' in tilt_series_df.index \
             else tilt_series_df['rlnMicrographOriginalPixelSize'],
         nominal_rotation_angle=tilt_image_df['rlnTomoNominalTiltAxisAngle'][0],
         output_directory=imod_directory,
@@ -68,7 +68,7 @@ def align_single_tilt_series(
         write_single_tilt_series_alignment_output(
             tilt_image_df=tilt_image_df,
             tilt_series_id=tilt_series_id,
-            pixel_size=tilt_series_df['rlnMicrographPixelSize'] if 'rlnMicrographPixelSize' in tilt_series_df.index \
+            pixel_size=tilt_series_df['rlnTomoTiltSeriesPixelSize'] if 'rlnTomoTiltSeriesPixelSize' in tilt_series_df.index \
                 else tilt_series_df['rlnMicrographOriginalPixelSize'],
             alignment_directory=imod_directory,
             output_star_file=metadata_directory / tilt_image_metadata_filename,

--- a/tomography_preprocessing/tilt_series_alignment/imod/align_tilt_series.py
+++ b/tomography_preprocessing/tilt_series_alignment/imod/align_tilt_series.py
@@ -56,8 +56,7 @@ def align_single_tilt_series(
     alignment_function(
         tilt_series_file=stack_directory / tilt_series_filename,
         tilt_angles=tilt_image_df['rlnTomoNominalStageTiltAngle'],
-        pixel_size=tilt_series_df['rlnTomoTiltSeriesPixelSize'] if 'rlnTomoTiltSeriesPixelSize' in tilt_series_df.index \
-            else tilt_series_df['rlnMicrographOriginalPixelSize'],
+        pixel_size=tilt_series_df['rlnTomoTiltSeriesPixelSize'],
         nominal_rotation_angle=tilt_image_df['rlnTomoNominalTiltAxisAngle'][0],
         output_directory=imod_directory,
         **alignment_function_kwargs,
@@ -68,8 +67,7 @@ def align_single_tilt_series(
         write_single_tilt_series_alignment_output(
             tilt_image_df=tilt_image_df,
             tilt_series_id=tilt_series_id,
-            pixel_size=tilt_series_df['rlnTomoTiltSeriesPixelSize'] if 'rlnTomoTiltSeriesPixelSize' in tilt_series_df.index \
-                else tilt_series_df['rlnMicrographOriginalPixelSize'],
+            pixel_size=tilt_series_df['rlnTomoTiltSeriesPixelSize'],
             alignment_directory=imod_directory,
             output_star_file=metadata_directory / tilt_image_metadata_filename,
         )

--- a/tomography_preprocessing/tilt_series_alignment/imod/batch_fiducials.py
+++ b/tomography_preprocessing/tilt_series_alignment/imod/batch_fiducials.py
@@ -13,6 +13,7 @@ from ...utils.relion import relion_pipeline_job
 
 console = Console(record=True)
 
+
 @cli.command(name='IMOD:fiducials')
 @relion_pipeline_job
 def batch_fiducials(
@@ -33,7 +34,7 @@ def batch_fiducials(
     if not tilt_series_star_file.exists():
         e = 'Could not find tilt series star file'
         console.log(f'ERROR: {e}')
-        raise RuntimeError(e)    
+        raise RuntimeError(e)
     console.log('Extracting metadata for all tilt series.')
     tilt_series_metadata = utils.star.iterate_tilt_series_metadata(
         tilt_series_star_file=tilt_series_star_file,

--- a/tomography_preprocessing/utils/star.py
+++ b/tomography_preprocessing/utils/star.py
@@ -37,11 +37,11 @@ def _extract_single_tilt_series_metadata(
 ) -> TiltSeriesMetadata:
     """Get metadata for a specific tilt-series from a tilt-series data STAR file."""
     star = starfile.read(tilt_series_star_file, always_dict=True)
-    #Check if Tomogram Name provided is actually found in the star file
+    # Check if Tomogram Name provided is actually found in the star file
     if not star['global']['rlnTomoName'].str.contains(tilt_series_id).any():
         e = 'Specified Tomogram provided in Tomogram-Name is not found in rlnTomoName in the given star file.'
         console.log(f'ERROR: {e}')
-        raise RuntimeError(e)		
+        raise RuntimeError(e)
     tilt_series_df = star['global'].set_index('rlnTomoName').loc[tilt_series_id, :]
     tilt_image_df = starfile.read(
         tilt_series_df['rlnTomoTiltSeriesStarFile'], always_dict=True
@@ -55,15 +55,11 @@ def iterate_tilt_series_metadata(
 ) -> Iterable[TiltSeriesMetadata]:
     """Yield metadata from a tilt-series data STAR file."""
     if tilt_series_id is None:  # align all tilt-series
-        all_tilt_series_metadata = utils.star._iterate_all_tilt_series_metadata(tilt_series_star_file)
+        all_tilt_series_metadata = utils.star._iterate_all_tilt_series_metadata(
+            tilt_series_star_file)
     else:  # do single tilt-series alignment
         all_tilt_series_metadata = [
             utils.star._extract_single_tilt_series_metadata(tilt_series_star_file, tilt_series_id)
         ]
     for tilt_series_metadata in all_tilt_series_metadata:
         yield tilt_series_metadata
-
-
-def get_pixel_size(optics_df: pd.DataFrame, optics_group: int) -> float:
-    """Get pixel size for an optics group from an optics dataframe."""
-    return optics_df.set_index('rlnOpticsGroup').loc[optics_group, 'rlnMicrographPixelSize']


### PR DESCRIPTION
Sjors asked for this change to make it easier to interface with existing cpp code

also removed the behaviour of defaulting to `rlnMicrographOriginalPixelSize` :)

also removed some unused old code which referenced rlnMicrographPixelSize

Sorry for slightly unclean PR 

cc @EuanPyle 