### PR TITLE
Add gpu to aretomo

### DIFF
--- a/tomography_preprocessing/tilt_series_alignment/aretomo/_utils.py
+++ b/tomography_preprocessing/tilt_series_alignment/aretomo/_utils.py
@@ -4,4 +4,5 @@ def gpu_ids_string2tuple(
         gpu_ids: str
     ) -> Tuple:
     """Convert GPU  ID input from colon spaced (1:2:3) to no space inbetween GPU IDs (123)"""
+    gpu_ids = gpu_ids.replace(' ','')
     return tuple(map(int,gpu_ids.replace(':','')))

--- a/tomography_preprocessing/tilt_series_alignment/aretomo/_utils.py
+++ b/tomography_preprocessing/tilt_series_alignment/aretomo/_utils.py
@@ -1,6 +1,6 @@
 from typing import Tuple
 
-def gpu_ids_string2tuple(
+def coerce_gpu_ids(
         gpu_ids: str
     ) -> Tuple:
     """Convert GPU  ID input from colon spaced (1:2:3) to no space inbetween GPU IDs (123)"""

--- a/tomography_preprocessing/tilt_series_alignment/aretomo/_utils.py
+++ b/tomography_preprocessing/tilt_series_alignment/aretomo/_utils.py
@@ -4,5 +4,4 @@ def gpu_ids_string2tuple(
         gpu_ids: str
     ) -> Tuple:
     """Convert GPU  ID input from colon spaced (1:2:3) to no space inbetween GPU IDs (123)"""
-    gpu_ids = gpu_ids.replace(' ','')
-    return tuple(map(int,gpu_ids.replace(':','')))
+    return tuple(map(int, gpu_ids.strip().replace(':','')))

--- a/tomography_preprocessing/tilt_series_alignment/aretomo/_utils.py
+++ b/tomography_preprocessing/tilt_series_alignment/aretomo/_utils.py
@@ -1,0 +1,7 @@
+from typing import Tuple
+
+def gpu_ids_string2tuple(
+        gpu_ids: str
+    ) -> Tuple:
+    """Convert GPU  ID input from colon spaced (1:2:3) to no space inbetween GPU IDs (123)"""
+    return tuple(map(int,gpu_ids.replace(':','')))

--- a/tomography_preprocessing/tilt_series_alignment/aretomo/align_tilt_series.py
+++ b/tomography_preprocessing/tilt_series_alignment/aretomo/align_tilt_series.py
@@ -21,6 +21,7 @@ def align_single_tilt_series(
         n_patches_xy: Tuple[int, int],
         alignment_thickness_px: float,
         tilt_angle_offset_correction: bool,
+        gpu_id: str or None,
         job_directory: Path,
 ):
     """Align a single tilt-series in AreTomo using RELION tilt-series metadata.
@@ -35,6 +36,7 @@ def align_single_tilt_series(
     n_patches_xy: number of patches in x and y for local alignments
     alignment_thickness_px: thickness of intermediate reconstruction during alignments.
     tilt_angle_offset_correction: flag to enable/disable stage tilt offset correction (-TiltCor) in AreTomo
+    gpu_id: string to specify GPUs to use. Seperate via a space between each ID, e.g. 0 1 2 3
     job_directory: directory in which results will be stored.
     """
     console = Console(record=True)
@@ -71,6 +73,7 @@ def align_single_tilt_series(
         n_patches_xy=n_patches_xy,
         correct_tilt_angle_offset=tilt_angle_offset_correction,
         thickness_for_alignment=alignment_thickness_px,
+        gpu_id=gpu_id
     )
     console.log('Writing STAR file for aligned tilt-series')
     write_single_tilt_series_alignment_output(

--- a/tomography_preprocessing/tilt_series_alignment/aretomo/align_tilt_series.py
+++ b/tomography_preprocessing/tilt_series_alignment/aretomo/align_tilt_series.py
@@ -3,9 +3,9 @@ from pathlib import Path
 import pandas as pd
 from lil_aretomo import run_aretomo_alignment
 from rich.console import Console
-from typing import Tuple
+from typing import Optional, Tuple
 
-from ._utils import gpu_ids_string2tuple
+from ._utils import coerce_gpu_ids
 
 from .._job_utils import (
     create_alignment_job_directory_structure,
@@ -23,7 +23,7 @@ def align_single_tilt_series(
         n_patches_xy: Tuple[int, int],
         alignment_thickness_px: float,
         tilt_angle_offset_correction: bool,
-        gpu_ids: str or None,
+        gpu_ids: Optional[str],
         job_directory: Path,
 ):
     """Align a single tilt-series in AreTomo using RELION tilt-series metadata.
@@ -38,7 +38,7 @@ def align_single_tilt_series(
     n_patches_xy: number of patches in x and y for local alignments
     alignment_thickness_px: thickness of intermediate reconstruction during alignments.
     tilt_angle_offset_correction: flag to enable/disable stage tilt offset correction (-TiltCor) in AreTomo
-    gpu_id: string to specify GPUs. GPU identifiers should be separated by colons e.g. 0:1:2:3
+    gpu_ids: string to specify GPUs. GPU identifiers should be separated by colons e.g. 0:1:2:3
     job_directory: directory in which results will be stored.
     """
     console = Console(record=True)
@@ -65,7 +65,7 @@ def align_single_tilt_series(
     )
     
     #Convert GPU ID string to tuple
-    gpu_ids = gpu_ids_string2tuple(
+    gpu_ids = coerce_gpu_ids(
         gpu_ids=gpu_ids
     )
     

--- a/tomography_preprocessing/tilt_series_alignment/aretomo/align_tilt_series.py
+++ b/tomography_preprocessing/tilt_series_alignment/aretomo/align_tilt_series.py
@@ -5,6 +5,8 @@ from lil_aretomo import run_aretomo_alignment
 from rich.console import Console
 from typing import Tuple
 
+from ._utils import gpu_ids_string2tuple
+
 from .._job_utils import (
     create_alignment_job_directory_structure,
     write_single_tilt_series_alignment_output
@@ -21,7 +23,7 @@ def align_single_tilt_series(
         n_patches_xy: Tuple[int, int],
         alignment_thickness_px: float,
         tilt_angle_offset_correction: bool,
-        gpu_id: str or None,
+        gpu_ids: str or None,
         job_directory: Path,
 ):
     """Align a single tilt-series in AreTomo using RELION tilt-series metadata.
@@ -36,7 +38,7 @@ def align_single_tilt_series(
     n_patches_xy: number of patches in x and y for local alignments
     alignment_thickness_px: thickness of intermediate reconstruction during alignments.
     tilt_angle_offset_correction: flag to enable/disable stage tilt offset correction (-TiltCor) in AreTomo
-    gpu_id: string to specify GPUs to use. Seperate via a colon between each ID, e.g. 0:1:2:3
+    gpu_id: string to specify GPUs. GPU identifiers should be separated by colons e.g. 0:1:2:3
     job_directory: directory in which results will be stored.
     """
     console = Console(record=True)
@@ -61,6 +63,12 @@ def align_single_tilt_series(
         image_files=tilt_image_df['rlnMicrographName'],
         output_image_file=stack_directory / tilt_series_filename
     )
+    
+    #Convert GPU ID string to tuple
+    gpu_ids = gpu_ids_string2tuple(
+        gpu_ids=gpu_ids
+    )
+    
     console.log('Running AreTomo')
     run_aretomo_alignment(
         tilt_series_file=stack_directory / tilt_series_filename,
@@ -73,7 +81,7 @@ def align_single_tilt_series(
         n_patches_xy=n_patches_xy,
         correct_tilt_angle_offset=tilt_angle_offset_correction,
         thickness_for_alignment=alignment_thickness_px,
-        gpu_id=gpu_id
+        gpu_ids=gpu_ids
     )
     console.log('Writing STAR file for aligned tilt-series')
     write_single_tilt_series_alignment_output(

--- a/tomography_preprocessing/tilt_series_alignment/aretomo/align_tilt_series.py
+++ b/tomography_preprocessing/tilt_series_alignment/aretomo/align_tilt_series.py
@@ -57,10 +57,10 @@ def align_single_tilt_series(
     # Create tilt-series stack and align using IMOD
     # implicit assumption - one tilt-axis angle per tilt-series
     console.log('Creating tilt series stack')
-    #utils.image.stack_image_files(
-    #    image_files=tilt_image_df['rlnMicrographName'],
-    #    output_image_file=stack_directory / tilt_series_filename
-    #)
+    utils.image.stack_image_files(
+        image_files=tilt_image_df['rlnMicrographName'],
+        output_image_file=stack_directory / tilt_series_filename
+    )
     console.log('Running AreTomo')
     run_aretomo_alignment(
         tilt_series_file=stack_directory / tilt_series_filename,

--- a/tomography_preprocessing/tilt_series_alignment/aretomo/align_tilt_series.py
+++ b/tomography_preprocessing/tilt_series_alignment/aretomo/align_tilt_series.py
@@ -36,7 +36,7 @@ def align_single_tilt_series(
     n_patches_xy: number of patches in x and y for local alignments
     alignment_thickness_px: thickness of intermediate reconstruction during alignments.
     tilt_angle_offset_correction: flag to enable/disable stage tilt offset correction (-TiltCor) in AreTomo
-    gpu_id: string to specify GPUs to use. Seperate via a space between each ID, e.g. 0 1 2 3
+    gpu_id: string to specify GPUs to use. Seperate via a colon between each ID, e.g. 0:1:2:3
     job_directory: directory in which results will be stored.
     """
     console = Console(record=True)
@@ -57,10 +57,10 @@ def align_single_tilt_series(
     # Create tilt-series stack and align using IMOD
     # implicit assumption - one tilt-axis angle per tilt-series
     console.log('Creating tilt series stack')
-    utils.image.stack_image_files(
-        image_files=tilt_image_df['rlnMicrographName'],
-        output_image_file=stack_directory / tilt_series_filename
-    )
+    #utils.image.stack_image_files(
+    #    image_files=tilt_image_df['rlnMicrographName'],
+    #    output_image_file=stack_directory / tilt_series_filename
+    #)
     console.log('Running AreTomo')
     run_aretomo_alignment(
         tilt_series_file=stack_directory / tilt_series_filename,

--- a/tomography_preprocessing/tilt_series_alignment/aretomo/batch.py
+++ b/tomography_preprocessing/tilt_series_alignment/aretomo/batch.py
@@ -38,7 +38,7 @@ def batch_aretomo(
     alignment_thickness: thickness of intermediate reconstructions during alignments in px.
     tomogram_name: 'rlnTomoName' for a specific tilt-series.
     tilt_angle_offset_correction: flag to enable/disable stage tilt offset correction (-TiltCor) in AreTomo
-    gpu_id: string to specify GPUs. GPU identifiers should be separated by colons e.g. 0:1:2:3
+    gpu_ids: string to specify GPUs. GPU identifiers should be separated by colons e.g. 0:1:2:3
 
     Returns
     -------

--- a/tomography_preprocessing/tilt_series_alignment/aretomo/batch.py
+++ b/tomography_preprocessing/tilt_series_alignment/aretomo/batch.py
@@ -24,7 +24,7 @@ def batch_aretomo(
         alignment_thickness: Optional[float] = typer.Option(800),
         tomogram_name: Optional[str] = typer.Option(None),
         tilt_angle_offset_correction: Optional[bool] = typer.Option(False),
-        gpu_id: Optional[str] = typer.Option(None)
+        gpu_ids: Optional[str] = typer.Option(None)
 ):
     """Align one or multiple tilt-series in AreTomo using RELION tilt-series metadata.
 
@@ -38,7 +38,7 @@ def batch_aretomo(
     alignment_thickness: thickness of intermediate reconstructions during alignments in px.
     tomogram_name: 'rlnTomoName' for a specific tilt-series.
     tilt_angle_offset_correction: flag to enable/disable stage tilt offset correction (-TiltCor) in AreTomo
-    gpu_id: If you wish to run in parallel over multiple GPUs, enter GPU IDs separated by colons. e.g. 0:1:2:3
+    gpu_id: string to specify GPUs. GPU identifiers should be separated by colons e.g. 0:1:2:3
 
     Returns
     -------
@@ -64,7 +64,7 @@ def batch_aretomo(
             n_patches_xy=n_patches_xy,
             alignment_thickness_px=alignment_thickness,
             tilt_angle_offset_correction=tilt_angle_offset_correction,
-            gpu_id=gpu_id,
+            gpu_ids=gpu_ids,
             job_directory=output_directory,
         )
     if tomogram_name is None:  # write out STAR file for set of tilt-series

--- a/tomography_preprocessing/tilt_series_alignment/aretomo/batch.py
+++ b/tomography_preprocessing/tilt_series_alignment/aretomo/batch.py
@@ -38,7 +38,7 @@ def batch_aretomo(
     alignment_thickness: thickness of intermediate reconstructions during alignments in px.
     tomogram_name: 'rlnTomoName' for a specific tilt-series.
     tilt_angle_offset_correction: flag to enable/disable stage tilt offset correction (-TiltCor) in AreTomo
-    gpu_id: If you wish to run in parallel over multiple GPUs, enter GPU IDs with spaces in between. e.g. 0 1 2 3
+    gpu_id: If you wish to run in parallel over multiple GPUs, enter GPU IDs separated by colons. e.g. 0:1:2:3
 
     Returns
     -------

--- a/tomography_preprocessing/tilt_series_alignment/aretomo/batch.py
+++ b/tomography_preprocessing/tilt_series_alignment/aretomo/batch.py
@@ -24,6 +24,7 @@ def batch_aretomo(
         alignment_thickness: Optional[float] = typer.Option(800),
         tomogram_name: Optional[str] = typer.Option(None),
         tilt_angle_offset_correction: Optional[bool] = typer.Option(False),
+        gpu_id: Optional[str] = typer.Option(None)
 ):
     """Align one or multiple tilt-series in AreTomo using RELION tilt-series metadata.
 
@@ -37,6 +38,7 @@ def batch_aretomo(
     alignment_thickness: thickness of intermediate reconstructions during alignments in px.
     tomogram_name: 'rlnTomoName' for a specific tilt-series.
     tilt_angle_offset_correction: flag to enable/disable stage tilt offset correction (-TiltCor) in AreTomo
+    gpu_id: If you wish to run in parallel over multiple GPUs, enter GPU IDs with spaces in between. e.g. 0 1 2 3
 
     Returns
     -------
@@ -62,6 +64,7 @@ def batch_aretomo(
             n_patches_xy=n_patches_xy,
             alignment_thickness_px=alignment_thickness,
             tilt_angle_offset_correction=tilt_angle_offset_correction,
+            gpu_id=gpu_id,
             job_directory=output_directory,
         )
     if tomogram_name is None:  # write out STAR file for set of tilt-series

--- a/tomography_preprocessing/tilt_series_alignment/imod/batch_fiducials.py
+++ b/tomography_preprocessing/tilt_series_alignment/imod/batch_fiducials.py
@@ -35,7 +35,7 @@ def batch_fiducials(
         e = 'Could not find tilt series star file'
         console.log(f'ERROR: {e}')
         raise RuntimeError(e)
-    console.log('Extracting metadata for all tilt series.')
+    console.log('Extracting metadata for tilt series.')
     tilt_series_metadata = utils.star.iterate_tilt_series_metadata(
         tilt_series_star_file=tilt_series_star_file,
         tilt_series_id=tomogram_name

--- a/tomography_preprocessing/tilt_series_alignment/imod/batch_patch_tracking.py
+++ b/tomography_preprocessing/tilt_series_alignment/imod/batch_patch_tracking.py
@@ -36,7 +36,7 @@ def batch_patch_tracking(
         e = 'Could not find tilt series star file'
         console.log(f'ERROR: {e}')
         raise RuntimeError(e)
-    console.log('Extracting metadata for all tilt series.')
+    console.log('Extracting metadata for tilt series.')
     tilt_series_metadata = utils.star.iterate_tilt_series_metadata(
         tilt_series_star_file=tilt_series_star_file,
         tilt_series_id=tomogram_name


### PR DESCRIPTION
Allows user to specify GPU in the exact same manner as MotionCor2 in rln e.g. user provides a string with colon separated GPU IDs: 0:1:2:3